### PR TITLE
Improved data + new features

### DIFF
--- a/components/Congestion.tsx
+++ b/components/Congestion.tsx
@@ -1,7 +1,7 @@
 import {TrafficLevel} from '../types.ts';
 
 type CongestionProps = {
-	level: TrafficLevel;
+	level: TrafficLevel | null;
 };
 
 const CONGESTION_TO_LABEL: Record<TrafficLevel, string> = {
@@ -20,12 +20,56 @@ const CONGESTION_TO_CLASS: Record<TrafficLevel, string> = {
 	[TrafficLevel.Unknown]: 'bg-gray-100 text-gray-800',
 };
 
-const Congestion = ({level}: CongestionProps) => {
+export const Congestion = ({level}: CongestionProps) => {
+	if (level === null) return null;
+
 	const label = CONGESTION_TO_LABEL[level];
 	const className = CONGESTION_TO_CLASS[level];
 	const finalClass = `inline-flex items-baseline px-2.5 py-0.5 rounded-full text-sm font-medium md:mt-2 lg:mt-0 ${className}`;
 
 	return <div className={finalClass}>{label}</div>;
+};
+
+const getDifferenceLabel = (difference: number) => {
+	if (difference > 0) {
+		return `${difference}\u00A0MPH faster than Local`;
+	} else if (difference < 0) {
+		return `${-difference}\u00A0MPH slower than Local`;
+	}
+
+	return 'Same as Local';
+};
+
+const getDifferenceClass = (difference: number) => {
+	if (Math.abs(difference) <= 1) {
+		return 'bg-blue-100 text-blue-800';
+	} else if (difference > 0) {
+		return 'bg-green-100 text-green-800';
+	} else {
+		return 'bg-red-100 text-red-800';
+	}
+};
+
+export const LocalComparison = ({
+	express,
+	local,
+}: {
+	express: number | null;
+	local: number | null;
+}) => {
+	if (express === null || local === null) return null;
+
+	const difference = express - local;
+	const color = getDifferenceClass(difference);
+	const label = getDifferenceLabel(difference);
+
+	return (
+		<div
+			className={`inline-flex items-baseline px-2.5 py-0.5 rounded-full text-sm font-medium md:mt-2 lg:mt-0 ${color}`}
+		>
+			{label}
+		</div>
+	);
 };
 
 export default Congestion;

--- a/components/TravelTimeDifference.tsx
+++ b/components/TravelTimeDifference.tsx
@@ -13,7 +13,7 @@ const TravelTimeDifference = ({
 			: travelTime - averageTravelTime;
 
 	if (difference === null) {
-		return <div>Unknown</div>;
+		return null;
 	} else if (difference > 0) {
 		return (
 			<div className="inline-flex items-baseline px-2.5 py-0.5 rounded-full text-sm font-medium bg-red-100 text-red-800 md:mt-2 lg:mt-0">

--- a/data/index.ts
+++ b/data/index.ts
@@ -1,0 +1,59 @@
+import {Direction, TrafficLevel} from '../types.ts';
+import getSigAlertData from './sigalert.ts';
+import getTravelMidwestData from './travelmidwest.ts';
+
+const TIMEOUT_MS = 3_000;
+
+export async function request<T>(args: RequestInfo): Promise<T | null> {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+	try {
+		const response = await fetch(args, {
+			signal: controller.signal,
+		});
+		clearTimeout(timeout);
+		if (!response.ok) return null;
+		return response.json();
+	} catch (error) {
+		clearTimeout(timeout);
+		console.error(error);
+		return null;
+	}
+}
+
+export async function getData(): Promise<ExpressData> {
+	const sigAlertData = await getSigAlertData(); // This has more accurate direction determination
+	const travelMidwestData = await getTravelMidwestData(
+		sigAlertData?.direction,
+	); // This has more data
+
+	if (
+		sigAlertData &&
+		travelMidwestData &&
+		sigAlertData.direction !== Direction.Unknown &&
+		travelMidwestData.direction !== Direction.Unknown &&
+		sigAlertData.direction === travelMidwestData.direction
+	) {
+		// If both have the same result (not unknown), use the travel midwest since it has more complete data
+		return travelMidwestData;
+	} else if (sigAlertData && sigAlertData.direction !== Direction.Unknown) {
+		// Prioritize sig alert since it has more accurate direction determination
+		return sigAlertData;
+	} else {
+		// Fall back to travel midwest if available, otherwise return unknown
+		return (
+			travelMidwestData ?? {
+				direction: Direction.Unknown,
+			}
+		);
+	}
+}
+
+export interface ExpressData {
+	direction: Direction;
+	level?: TrafficLevel | null;
+	travelTime?: number | null;
+	averageTravelTime?: number | null;
+	speed?: number | null;
+	localSpd?: number | null;
+}

--- a/data/sigalert.ts
+++ b/data/sigalert.ts
@@ -1,0 +1,65 @@
+import {ExpressData, request} from './index.ts';
+import {Direction} from '../types.ts';
+
+export interface APIData {
+	speeds: Array<Array<Array<number[]> | number | null>>;
+	incidents: Array<
+		[
+			number, // ?
+			number, // ?
+			string, // Local Time (HH:MM AA)
+			string, // Message
+			string, // Title
+			number, // ?
+			number, // ?
+			number, // ?
+			string, // Initially Posted ISO Date
+			string, // Last Updated ISO Date
+		]
+	>;
+	cameras: Array<Array<number | string>>;
+}
+
+const MSG_BASE = 'Kennedy (I-90/94) Express Lanes';
+const DIRECTION_MSG_MAP = [
+	{
+		direction: Direction.Inbound,
+		startsWith: `${MSG_BASE} West`,
+	},
+	{
+		direction: Direction.Outbound,
+		startsWith: `${MSG_BASE} East`,
+	},
+];
+
+export default async function getData(): Promise<ExpressData | null> {
+	const pathData = await request<{path: string; cacheBuster: string}>(
+		'https://www.sigalert.com/Data/Chicago/path.json',
+	);
+	if (!pathData) return null;
+	const fullUrl = `https://www.sigalert.com/Data/${pathData.path}/ChicagoData.json?cb=${pathData.cacheBuster}`;
+	const data = await request<APIData>(fullUrl);
+	if (!data) return null;
+
+	const activeDirections = DIRECTION_MSG_MAP.filter(direction =>
+		data.incidents.some(
+			data =>
+				data[3].startsWith(direction.startsWith) &&
+				data[4] === 'Closed',
+		),
+	);
+
+	if (activeDirections.length === 0 || activeDirections.length > 2) {
+		return {
+			direction: Direction.Unknown,
+		};
+	} else if (activeDirections.length === 2) {
+		return {
+			direction: Direction.Closed,
+		};
+	} else {
+		return {
+			direction: activeDirections[0].direction,
+		};
+	}
+}

--- a/data/travelmidwest.ts
+++ b/data/travelmidwest.ts
@@ -1,0 +1,155 @@
+import {Direction, TrafficLevel} from '../types.ts';
+import {ExpressData, request} from './index.ts';
+
+const URL = `https://www.travelmidwest.com/lmiga/travelTime.json?path=GATEWAY.IL.KENNEDY`;
+const PATH_BASE = `GATEWAY.IL.KENNEDY.KENNEDY`;
+const PATH_BASE_REV = `${PATH_BASE} REVERSIBLE`;
+
+// The _MAIN IDs are for the full length of the express lanes,
+// which can be used for travel time.
+// The _ALL IDs are for the shorter sections of the express lanes,
+// which cannot be used for travel time, but can be used for other data.
+
+const PATH_INBOUND_LOCAL = `${PATH_BASE} EB`;
+const PATH_INBOUND_REV = `${PATH_BASE_REV} EB`;
+const ID_INBOUND_MAIN = 'IL-TESTTSC-249';
+const IDS_INBOUND_ALL = ['IL-TSCDMS-EB_I_90 Express_ADDISON_TO_OHIO_342'];
+const ID_INBOUND_LOCAL = 'IL-TSCDMS-EB_I_90_PULASKI_TO_OHIO_642';
+
+const PATH_OUTBOUND_LOCAL = `${PATH_BASE} WB`;
+const PATH_OUTBOUND_REV = `${PATH_BASE_REV} WB`;
+const ID_OUTBOUND_MAIN = 'IL-TESTTSC-250';
+const IDS_OUTBOUND_ALL = ['IL-TSCDMS-WB_I_90 Express_ARMITAGE_TO_MONTROSE_341'];
+const ID_OUTBOUND_LOCAL = 'IL-TSCDMS-WB_I_90_DAMEN_TO_MONTROSE_343';
+
+const DIRECTION_LOCAL_MAP = {
+	[Direction.Inbound]: {
+		path: PATH_INBOUND_LOCAL,
+		id: ID_INBOUND_LOCAL,
+	},
+	[Direction.Outbound]: {
+		path: PATH_OUTBOUND_LOCAL,
+		id: ID_OUTBOUND_LOCAL,
+	},
+} as const satisfies Partial<
+	Record<
+		Direction,
+		{
+			path: string;
+			id: string;
+		}
+	>
+>;
+
+interface ReportRow {
+	avg: number;
+	from: string;
+	id: string;
+	len: number;
+	level: TrafficLevel;
+	on: string;
+	ovrAvg: boolean;
+	spd: `${number}` | 'N/A';
+	to: string;
+	tt: number;
+}
+
+type APIResponse = Array<{
+	tablePath: string;
+	reportRows: ReportRow[];
+	tableName: string;
+}>;
+
+function sortFn(a: ReportRow, b: ReportRow) {
+	// Put ones with actual travel time first
+	if (a.tt !== -1 && b.tt === -1) return -1;
+	if (a.tt === -1 && b.tt !== -1) return 1;
+
+	// Sort MAIN first
+	if (a.id === ID_INBOUND_MAIN) return -1;
+	if (b.id === ID_INBOUND_MAIN) return 1;
+
+	return 0;
+}
+
+export default async function getData(
+	knownDirection?: Direction,
+): Promise<ExpressData | null> {
+	const data = await request<APIResponse>(URL);
+
+	const inboundDataRow = data?.find(
+		row => row.tablePath === PATH_INBOUND_REV,
+	);
+	const inboundData = inboundDataRow?.reportRows
+		.filter(row => [ID_INBOUND_MAIN, ...IDS_INBOUND_ALL].includes(row.id))
+		.sort(sortFn)[0];
+
+	const outboundDataRow = data?.find(
+		row => row.tablePath === PATH_OUTBOUND_REV,
+	);
+	const outboundData = outboundDataRow?.reportRows
+		.filter(row => [ID_OUTBOUND_MAIN, ...IDS_OUTBOUND_ALL].includes(row.id))
+		.sort(sortFn)[0];
+
+	const isInbound =
+		inboundData &&
+		inboundData?.level !== 'Unknown' &&
+		(!knownDirection || knownDirection === Direction.Inbound);
+	const isOutbound =
+		outboundData &&
+		outboundData?.level !== 'Unknown' &&
+		(!knownDirection || knownDirection === Direction.Outbound);
+	// If we are missing some data or are both inbound and outbound simultaneously, the data should be considered unreliable
+	const isUnreliable =
+		!inboundData || !outboundData || (isInbound && isOutbound);
+
+	if (isUnreliable) {
+		return {
+			direction: Direction.Unknown,
+		};
+	} else if (!isInbound && !isOutbound) {
+		return {
+			direction: Direction.Closed,
+		};
+	} else {
+		const rowData = isInbound ? inboundData : outboundData;
+		if (rowData) {
+			const direction = isInbound
+				? Direction.Inbound
+				: Direction.Outbound;
+
+			let travelTime: number | null = null;
+			let averageTravelTime: number | null = null;
+			if ([ID_INBOUND_MAIN, ID_OUTBOUND_MAIN].includes(rowData.id)) {
+				travelTime = rowData.tt === -1 ? null : Math.round(rowData.tt);
+				averageTravelTime =
+					rowData.avg === -1 ? null : Math.round(rowData.avg);
+			}
+			const speed =
+				rowData.spd === 'N/A'
+					? null
+					: Math.round(parseFloat(rowData.spd));
+			const level = rowData.level;
+
+			const localDataMap = DIRECTION_LOCAL_MAP[direction];
+			const localData = data
+				?.find(row => row.tablePath === localDataMap.path)
+				?.reportRows.find(row => row.id === localDataMap.id);
+			const localSpd =
+				!localData || localData.spd === 'N/A'
+					? null
+					: Math.round(parseFloat(localData.spd));
+
+			return {
+				direction,
+				travelTime,
+				averageTravelTime,
+				speed,
+				level,
+				localSpd,
+			};
+		}
+	}
+
+	return null;
+}

--- a/islands/Theme.tsx
+++ b/islands/Theme.tsx
@@ -17,7 +17,7 @@ export default function Theme() {
     if (
       localStorage.theme === "dark" ||
       (!("theme" in localStorage) &&
-        window.matchMedia("(prefers-color-scheme: dark)").matches)
+        globalThis.matchMedia("(prefers-color-scheme: dark)").matches)
     ) {
       document.documentElement.classList.add("dark");
       setMode("dark");


### PR DESCRIPTION
- Use an alternate data source, [sigalert](https://www.sigalert.com/) (found on the [ABC 7 traffic website](https://abc7chicago.com/traffic/)) to more accurately determine direction of travel based on the indicated closures. Travel midwest is still used for any additional data (travel times, speeds, etc) or as a fallback if sigalert is unavailable.
- Add comparison to local speeds: is it really worth it to take the express lanes right now?
![Screenshot on 2025-01-13 at 10 29 42](https://github.com/user-attachments/assets/71857b82-7c46-433d-83ec-793755eb5aa7)
![Screenshot on 2025-01-13 at 09 36 52](https://github.com/user-attachments/assets/760fb4b6-ec83-492d-b6aa-50f99750a068)
- Minor UI tweaks and other improvements